### PR TITLE
change type of dispatchedValues in distinct() from MutableList to Mut…

### DIFF
--- a/lives/src/main/java/com/snakydesign/livedataextensions/Filtering.kt
+++ b/lives/src/main/java/com/snakydesign/livedataextensions/Filtering.kt
@@ -18,7 +18,7 @@ import com.snakydesign.livedataextensions.livedata.SingleLiveData
  */
 fun <T> LiveData<T>.distinct(): LiveData<T> {
     val mutableLiveData: MediatorLiveData<T> = MediatorLiveData()
-    val dispatchedValues = mutableListOf<T?>()
+    val dispatchedValues = mutableSetOf<T?>()
     mutableLiveData.addSource(this) {
         if(!dispatchedValues.contains(it)) {
             mutableLiveData.value = it


### PR DESCRIPTION
I think of `MutableSet` is better than `MutableList` for the type of `val dispatchedValues` in `LiveData.distinct()` extension.