### PR TITLE
Ensure distinctUntilChanged handle observers that mutate source LiveData

### DIFF
--- a/lives/src/test/java/com/snakydesign/livedataextensions/FilteringTest.kt
+++ b/lives/src/test/java/com/snakydesign/livedataextensions/FilteringTest.kt
@@ -6,6 +6,7 @@ import android.arch.lifecycle.Observer
 import org.junit.*
 import org.mockito.Mockito
 import org.mockito.Mockito.times
+import java.lang.IllegalStateException
 import kotlin.test.assertEquals
 
 /**
@@ -96,6 +97,25 @@ class FilteringTest {
         assertEquals(2,testingLiveData.value)
 
         Mockito.verifyNoMoreInteractions(observer)
+    }
+
+    @Test
+    fun `test LiveData distinctUntilChanged updating source from observer doesn't trigger change`() {
+        val sourceLiveData = MutableLiveData<Int>()
+        var timesCalled = 0
+        val observer = Observer<Int> { t ->
+            timesCalled++
+            // set same value from observer
+            sourceLiveData.value = t
+        }
+        val testingLiveData = sourceLiveData.distinctUntilChanged()
+        testingLiveData.observeForever(observer)
+
+        sourceLiveData.value = 2
+
+        if (timesCalled > 1) {
+            throw IllegalStateException()
+        }
     }
 
     @Test


### PR DESCRIPTION
`latestValue = it` is executed only after new value is set to Mediator. This gives
observers possibilty to set new value to source LiveData before that assigment
is executed.

Luckily, LiveData handles this case by invalidating current dispatch of source
LiveData, and not dispatching immediately so currently everything works correctly.

I'm adding this test case to catch future regression, if LiveData behavior changes.