### PR TITLE
Fixed issue where removing observer and readding, would not reattach observer

### DIFF
--- a/lives/src/main/java/com/snakydesign/livedataextensions/livedata/NonNullLiveData.kt
+++ b/lives/src/main/java/com/snakydesign/livedataextensions/livedata/NonNullLiveData.kt
@@ -8,16 +8,21 @@ import androidx.lifecycle.Observer
  * Created by Adib Faramarzi
  * Only emits values that are not null
  */
-class NonNullLiveData<T>(liveData:LiveData<T>) : LiveData<T>() {
+class NonNullLiveData<T>(private val liveData:LiveData<T>) : LiveData<T>() {
     private val mediatorLiveData = MediatorLiveData<T>()
     private val mediatorObserver = Observer<T> {
         it?.let{
             this@NonNullLiveData.value = it
         }
     }
+
     init {
-            mediatorLiveData.observeForever(mediatorObserver)
-            mediatorLiveData.addSource(liveData, mediatorObserver)
+        mediatorLiveData.addSource(liveData, mediatorObserver)
+    }
+
+    override fun onActive() {
+        super.onActive()
+        mediatorLiveData.observeForever(mediatorObserver)
     }
     override fun onInactive() {
         super.onInactive()

--- a/lives/src/test/java/com/snakydesign/livedataextensions/livedata/NonNullLiveDataTest.kt
+++ b/lives/src/test/java/com/snakydesign/livedataextensions/livedata/NonNullLiveDataTest.kt
@@ -41,4 +41,21 @@ class NonNullLiveDataTest {
         sourceLiveData1.value = null
         Mockito.verifyNoMoreInteractions(observer)
     }
+
+    @Test
+    fun `removing and readding observer in NonNullLiveData should remaing observing the source`(){
+        val observer= Mockito.mock(Observer::class.java) as Observer<Int>
+        val sourceLiveData1 = MutableLiveData<Int>()
+        val testingLiveData = sourceLiveData1.nonNull()
+        testingLiveData.observeForever(observer)
+        testingLiveData.removeObserver(observer)
+
+        val observer1= Mockito.mock(Observer::class.java) as Observer<Int>
+        testingLiveData.observeForever(observer1)
+        sourceLiveData1.value = null
+        sourceLiveData1.value = 2
+        Mockito.verify(observer1).onChanged(2)
+        sourceLiveData1.value = null
+        Mockito.verifyNoMoreInteractions(observer1)
+    }
 }


### PR DESCRIPTION
Fixed issue where removing observer and readding, much like doing a rotation change while the LiveData is inside a ViewModel.
Would call onInactive but keep the same instance of NonNullLiveData that would later call onActive.
I moved the observeForever inside onActive() method.
