### PR TITLE
Fix: Make startWith callable from any thread

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -6,7 +6,7 @@ ext.versionNumbers = [
 
         kotlin      : '1.3.20',
         mockito     : '2.21.0',
-        arch        : '2.0.0',
+        arch        : '2.1.0',
         junit       : '4.12',
 
         minSdk      : 16,


### PR DESCRIPTION
This PR implements `startWith` in such a way that it can be called from any thread.

The previous version called

```kotlin
finalLiveData.value = startingValue
```

in the thread that calls `startWith`.  This is problematic, because setting the value of a `LiveData` can only be done from the main thread.

This implementation avoids that and instead creates `startWith` as a merge of two `LiveData`s: the original source and a new live data from which only a single value is taken in case the source has not emitted a value.  This is a bit more complicated than the original version, but allows `startWith` to be called from any thread.

Unfortunately this is a breaking change in the sense that an attempt to get the value of the
 returned `LiveData` will return `null`, because the initial value will not be set until the returned `LiveData` is activated.
