### PR TITLE
Fix: Allow null initial value in distinctUntilChanged

### DIFF
--- a/lives/src/main/java/com/snakydesign/livedataextensions/Filtering.kt
+++ b/lives/src/main/java/com/snakydesign/livedataextensions/Filtering.kt
@@ -33,11 +33,11 @@ fun <T> LiveData<T>.distinct(): LiveData<T> {
  */
 fun <T> LiveData<T>.distinctUntilChanged(): LiveData<T> {
     val mutableLiveData: MediatorLiveData<T> = MediatorLiveData()
-    var latestValue : T? = null
+    var hasEmitted = false
     mutableLiveData.addSource(this) {
-        if(latestValue!=it) {
+        if (!hasEmitted || it != mutableLiveData.value) {
+            hasEmitted = true
             mutableLiveData.value = it
-            latestValue = it
         }
     }
     return mutableLiveData


### PR DESCRIPTION
This PR changes `distinctUntilChanged` to allow an initial `null` value.

The previous implementation of distinctUntilChanged used a variable

```kotlin
var latestValue : T? = null
```

and a check

```kotlin
if(latestValue!=it)
```

to filter out duplicates.  This has the problem that an initial `null` value emitted by the source will be implicitly dropped.

The new implementation uses a boolean variable to track whether the source has emitted anything.  In case it hasn't the initial value will be emitted.

The new implementation also does not keep the previous value in a separate value.  Rather the previous value is obtained from the returned live data.  This has the (minor) advantage that there is no need to allocate space for a separate variable to track the previous value.